### PR TITLE
Compatibility with numpy 1.24

### DIFF
--- a/igor/binarywave.py
+++ b/igor/binarywave.py
@@ -107,7 +107,7 @@ class NullStaticStringField (StaticStringField):
 # From IgorMath.h
 TYPE_TABLE = {        # (key: integer flag, value: numpy dtype)
     0:None,           # Text wave, not handled in ReadWave.c
-    1:_numpy.complex, # NT_CMPLX, makes number complex.
+    1:complex,        #_numpy.complex is depreciated as of 1.20, using inbuilt.
     2:_numpy.float32, # NT_FP32, 32 bit fp numbers.
     3:_numpy.complex64,
     4:_numpy.float64, # NT_FP64, 64 bit fp numbers.


### PR DESCRIPTION
numpy.complex is depreciated (since numpy 1.20) and its use now throws an error (since numpy 1.24). Error advises that the built-in function "complex" behaves identically.

This commit replaces "numpy.complex" with "complex"